### PR TITLE
feat(logging): add k8s_log_exclusions and fix custom_exclusions

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -205,6 +205,25 @@ module "infrastructure_elements" {
       enabled                = false
       description            = "Silence DEBUG/INFO logs for all workloads on the dev cluster (disabled by default)"
     }
+    # Example: namespace + container_name selector — target a specific container
+    "typesense-stage-container-filter" = {
+      scope                  = "namespace"
+      namespace              = "typesense-clusters-stage"
+      container_name         = "typesense"
+      exclude_below_severity = "ERROR"
+      enabled                = true
+      description            = "Suppress INFO/WARNING logs from the typesense container only in stage"
+    }
+    # Example: namespace + pod label selector — target pods by Kubernetes label
+    "typesense-stage-pod-label-filter" = {
+      scope                  = "namespace"
+      namespace              = "typesense-clusters-stage"
+      pod_label_key          = "app.kubernetes.io/name"
+      pod_label_value        = "typesense"
+      exclude_below_severity = "ERROR"
+      enabled                = true
+      description            = "Suppress INFO/WARNING logs from pods labelled app.kubernetes.io/name=typesense in stage"
+    }
   }
 
   # Custom log exclusions with arbitrary GCP filter strings.

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -176,4 +176,44 @@ module "infrastructure_elements" {
     network       = module.vpc.network_self_link
     source_ranges = [module.gke.master_ipv4_cidr_block]
   }
+
+  # Structured Kubernetes log exclusions.
+  # Each entry generates a GCP log exclusion scoped to a namespace or GKE cluster.
+  # The resource persists in state when enabled = false — toggle without destroy/recreate.
+  k8s_log_exclusions = {
+    # Silence Typesense Raft recovery noise in stage (actively enabled)
+    "typesense-stage-log-filter" = {
+      scope                  = "namespace"
+      namespace              = "typesense-clusters-stage"
+      exclude_below_severity = "ERROR"
+      enabled                = true
+      description            = "Suppress Typesense INFO/WARNING logs in stage to prevent billing runaway"
+    }
+    # Production filter created but disabled — activate during incidents
+    "typesense-prod-log-filter" = {
+      scope                  = "namespace"
+      namespace              = "typesense-clusters-main"
+      exclude_below_severity = "ERROR"
+      enabled                = false
+      description            = "Suppress Typesense INFO/WARNING logs in production (disabled by default)"
+    }
+    # Example: cluster-scoped exclusion for a dedicated dev cluster
+    "dev-cluster-log-filter" = {
+      scope                  = "cluster"
+      cluster_name           = "dev-cluster"
+      exclude_below_severity = "WARNING"
+      enabled                = false
+      description            = "Silence DEBUG/INFO logs for all workloads on the dev cluster (disabled by default)"
+    }
+  }
+
+  # Custom log exclusions with arbitrary GCP filter strings.
+  # Add enabled = false to deactivate without destroying the resource.
+  custom_exclusions = {
+    "my-app-debug-exclusion" = {
+      filter      = "resource.type=\"k8s_container\" AND resource.labels.namespace_name=\"my-app\" AND severity<\"WARNING\""
+      description = "Suppress debug logs from my-app namespace"
+      enabled     = true
+    }
+  }
 }

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -9,17 +9,19 @@ locals {
 
   # Generate GCP log filter expressions for k8s_log_exclusions entries.
   # Namespace scope targets a single Kubernetes namespace; cluster scope targets all namespaces in a GKE cluster.
+  # coalesce(..., "") guards against null interpolation when scope/namespace/cluster_name are inconsistent —
+  # the precondition on the resource will surface the intended error message before apply proceeds.
   k8s_log_exclusion_filters = {
     for k, v in var.k8s_log_exclusions : k => (
       v.scope == "namespace"
       ? join("\n", [
         "resource.type=\"k8s_container\"",
-        "resource.labels.namespace_name=\"${v.namespace}\"",
+        "resource.labels.namespace_name=\"${coalesce(v.namespace, "")}\"",
         "severity<\"${v.exclude_below_severity}\"",
       ])
       : join("\n", [
         "resource.type=\"k8s_container\"",
-        "resource.labels.cluster_name=\"${v.cluster_name}\"",
+        "resource.labels.cluster_name=\"${coalesce(v.cluster_name, "")}\"",
         "severity<\"${v.exclude_below_severity}\"",
       ])
     )

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -8,24 +8,28 @@ locals {
   probe_filter      = "resource.type=\"k8s_container\" AND (${local.probe_filter_expr})"
 
   # Generate GCP log filter expressions for k8s_log_exclusions entries.
-  # Namespace scope targets a single Kubernetes namespace; cluster scope targets all namespaces in a GKE cluster.
+  # Builds a dynamic clause list: base scope + optional container_name + optional pod label + severity.
   # trimspace(coalesce(..., "")) guards against null interpolation and trims whitespace-only values,
   # keeping filter generation consistent with the trimspace() checks in the resource preconditions.
   # Clauses are joined with AND to match established module style and avoid Cloud Logging filter ambiguity.
   k8s_log_exclusion_filters = {
-    for k, v in var.k8s_log_exclusions : k => (
+    for k, v in var.k8s_log_exclusions : k => join(" AND\n", concat(
+      # Base: resource type + scope clause
+      ["resource.type=\"k8s_container\""],
       v.scope == "namespace"
-      ? join(" AND\n", [
-        "resource.type=\"k8s_container\"",
-        "resource.labels.namespace_name=\"${trimspace(coalesce(v.namespace, ""))}\"",
-        "severity<\"${v.exclude_below_severity}\"",
-      ])
-      : join(" AND\n", [
-        "resource.type=\"k8s_container\"",
-        "resource.labels.cluster_name=\"${trimspace(coalesce(v.cluster_name, ""))}\"",
-        "severity<\"${v.exclude_below_severity}\"",
-      ])
-    )
+      ? ["resource.labels.namespace_name=\"${trimspace(coalesce(v.namespace, ""))}\""]
+      : ["resource.labels.cluster_name=\"${trimspace(coalesce(v.cluster_name, ""))}\""],
+      # Optional: container name selector
+      v.container_name != null && trimspace(v.container_name) != ""
+      ? ["resource.labels.container_name=\"${trimspace(v.container_name)}\""]
+      : [],
+      # Optional: pod label selector
+      v.pod_label_key != null && v.pod_label_value != null
+      ? ["labels.k8s-pod/${trimspace(v.pod_label_key)}=\"${trimspace(v.pod_label_value)}\""]
+      : [],
+      # Severity threshold (always last)
+      ["severity<\"${v.exclude_below_severity}\""],
+    ))
   }
 }
 
@@ -95,6 +99,21 @@ resource "google_logging_project_exclusion" "k8s_log_exclusions" {
     precondition {
       condition     = !(each.value.scope == "cluster" && (each.value.cluster_name == null || trimspace(each.value.cluster_name) == ""))
       error_message = "k8s_log_exclusions[\"${each.key}\"]: 'cluster_name' must be set to a non-empty string when scope is \"cluster\"."
+    }
+
+    precondition {
+      condition     = each.value.container_name == null || trimspace(each.value.container_name) != ""
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'container_name' must be non-empty when set."
+    }
+
+    precondition {
+      condition     = each.value.pod_label_key == null || trimspace(each.value.pod_label_key) != ""
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'pod_label_key' must be non-empty when set."
+    }
+
+    precondition {
+      condition     = each.value.pod_label_value == null || trimspace(each.value.pod_label_value) != ""
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'pod_label_value' must be non-empty when set."
     }
   }
 }

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -9,19 +9,20 @@ locals {
 
   # Generate GCP log filter expressions for k8s_log_exclusions entries.
   # Namespace scope targets a single Kubernetes namespace; cluster scope targets all namespaces in a GKE cluster.
-  # coalesce(..., "") guards against null interpolation when scope/namespace/cluster_name are inconsistent —
-  # the precondition on the resource will surface the intended error message before apply proceeds.
+  # trimspace(coalesce(..., "")) guards against null interpolation and trims whitespace-only values,
+  # keeping filter generation consistent with the trimspace() checks in the resource preconditions.
+  # Clauses are joined with AND to match established module style and avoid Cloud Logging filter ambiguity.
   k8s_log_exclusion_filters = {
     for k, v in var.k8s_log_exclusions : k => (
       v.scope == "namespace"
-      ? join("\n", [
+      ? join(" AND\n", [
         "resource.type=\"k8s_container\"",
-        "resource.labels.namespace_name=\"${coalesce(v.namespace, "")}\"",
+        "resource.labels.namespace_name=\"${trimspace(coalesce(v.namespace, ""))}\"",
         "severity<\"${v.exclude_below_severity}\"",
       ])
-      : join("\n", [
+      : join(" AND\n", [
         "resource.type=\"k8s_container\"",
-        "resource.labels.cluster_name=\"${coalesce(v.cluster_name, "")}\"",
+        "resource.labels.cluster_name=\"${trimspace(coalesce(v.cluster_name, ""))}\"",
         "severity<\"${v.exclude_below_severity}\"",
       ])
     )

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -6,6 +6,24 @@ locals {
   # Combine all filters into one string
   probe_filter_expr = join(" OR ", concat(local.json_payload_filters, local.text_payload_filters))
   probe_filter      = "resource.type=\"k8s_container\" AND (${local.probe_filter_expr})"
+
+  # Generate GCP log filter expressions for k8s_log_exclusions entries.
+  # Namespace scope targets a single Kubernetes namespace; cluster scope targets all namespaces in a GKE cluster.
+  k8s_log_exclusion_filters = {
+    for k, v in var.k8s_log_exclusions : k => (
+      v.scope == "namespace"
+      ? join("\n", [
+        "resource.type=\"k8s_container\"",
+        "resource.labels.namespace_name=\"${v.namespace}\"",
+        "severity<\"${v.exclude_below_severity}\"",
+      ])
+      : join("\n", [
+        "resource.type=\"k8s_container\"",
+        "resource.labels.cluster_name=\"${v.cluster_name}\"",
+        "severity<\"${v.exclude_below_severity}\"",
+      ])
+    )
+  }
 }
 
 resource "google_logging_project_exclusion" "probe_exclusion" {
@@ -51,4 +69,42 @@ resource "google_logging_project_exclusion" "fpm" {
   name        = "fpm-exclusion"
   description = "Exclude fpm logs"
   filter      = var.fpm
+}
+
+# Structured Kubernetes log exclusions. One resource per k8s_log_exclusions entry.
+# The resource persists in state even when enabled = false (disabled = true in GCP),
+# allowing toggle without destroy/recreate.
+resource "google_logging_project_exclusion" "k8s_log_exclusions" {
+  for_each = var.k8s_log_exclusions
+
+  project     = var.project_id
+  name        = each.key
+  description = each.value.description
+  filter      = local.k8s_log_exclusion_filters[each.key]
+  disabled    = !each.value.enabled
+
+  lifecycle {
+    precondition {
+      condition     = !(each.value.scope == "namespace" && (each.value.namespace == null || trimspace(each.value.namespace) == ""))
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'namespace' must be set to a non-empty string when scope is \"namespace\"."
+    }
+
+    precondition {
+      condition     = !(each.value.scope == "cluster" && (each.value.cluster_name == null || trimspace(each.value.cluster_name) == ""))
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'cluster_name' must be set to a non-empty string when scope is \"cluster\"."
+    }
+  }
+}
+
+# Custom log exclusions with arbitrary GCP filter strings.
+# The map key is used as the GCP exclusion name.
+# The resource persists in state even when enabled = false (disabled = true in GCP).
+resource "google_logging_project_exclusion" "custom_exclusions" {
+  for_each = var.custom_exclusions
+
+  project     = var.project_id
+  name        = each.key
+  description = each.value.description
+  filter      = each.value.filter
+  disabled    = !each.value.enabled
 }

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-11

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/design.md
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/design.md
@@ -1,0 +1,99 @@
+## Context
+
+`terraform-google-gcp-infrastructure-elements` is a shared Terraform module used across multiple GCP projects to provision common infrastructure elements: log exclusions, SSL policies, firewall rules. The `logging_exclusions.tf` file currently defines five named `google_logging_project_exclusion` resources — each with a hardcoded filter string passed as a variable — plus a `custom_exclusions` map-driven resource that lives, incorrectly, in `ssl.tf`.
+
+The named exclusions (probe, fpm, fluentbit, etc.) use `count = 0/1` toggled via `enable_exclusions` — toggling destroys/recreates the GCP resource. The `custom_exclusions` resource uses `for_each` and accepts raw filter strings, but has no `enabled` field, meaning disabling a custom exclusion requires removing it from the map and destroying the resource.
+
+Projects running Typesense on GKE need a way to suppress high-volume INFO/WARNING logs from specific namespaces without writing raw GCP filter expressions and without losing the resource on toggle.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `k8s_log_exclusions`: a `map(object(...))` variable that accepts structured inputs (scope, namespace/cluster_name, exclude_below_severity, enabled) and generates GCP filter expressions internally
+- Support `scope = "namespace"` (filters by `resource.labels.namespace_name`) and `scope = "cluster"` (filters by `resource.labels.cluster_name`)
+- Use `disabled = !var.enabled` semantics: the GCP resource persists in Terraform state when `enabled = false`, no destroy/recreate cycle on toggle
+- Fix `custom_exclusions`: add `enabled` field with same `disabled = !enabled` semantics
+- Relocate the `custom_exclusions` resource block from `ssl.tf` to `logging_exclusions.tf`
+- Add a `k8s_log_exclusions_ids` output (map of exclusion name → GCP resource ID)
+- Update examples to demonstrate both capabilities
+
+**Non-Goals:**
+- Changing the existing named exclusions (probe, fpm, etc.) or their toggle mechanism
+- Supporting pod-level or container-level scoping (namespace and cluster only)
+- Time-based automatic expiry (not supported by GCP API)
+- Replacing `custom_exclusions` — it remains for arbitrary filter strings
+
+## Decisions
+
+### D1: `k8s_log_exclusions` as `map(object(...))` with `for_each`
+
+**Decision:** Use a `map(object(...))` variable where the map key becomes the GCP exclusion name. Resource addressing uses `google_logging_project_exclusion.k8s_log_exclusions[key]`.
+
+**Rationale:** Map keys give stable Terraform resource addresses. Removing one entry only destroys that resource — no index shifting as with `list`. Map key = GCP exclusion name keeps naming explicit and under caller control.
+
+**Alternative considered:** A `list(object(...))` with a `name` field inside each object. Rejected — list indexing is fragile; adding/removing entries in the middle shifts all subsequent resource addresses.
+
+---
+
+### D2: `enabled` maps to `disabled = !enabled` (resource persists when inactive)
+
+**Decision:** Both `k8s_log_exclusions` entries and `custom_exclusions` entries expose `enabled = bool`. Internally this sets `disabled = !each.value.enabled` on the GCP resource. The resource is always created; toggling `enabled` only changes GCP's `disabled` flag.
+
+**Rationale:** Consistent with the luiss `log_filter` module design. For incident response scenarios (e.g., a Typesense Raft storm), operators toggle `enabled = true` and apply — no resource recreation, minimal blast radius. The existing named exclusions use `count = 0/1`, which is fine for static infrastructure but awkward for operational toggles.
+
+**Alternative considered:** Keep `count = 0/1` for `k8s_log_exclusions` consistent with existing named exclusions. Rejected — for namespace-scoped severity filters, toggle-without-destroy is the key operational requirement (it was the explicit motivation in the luiss incident).
+
+---
+
+### D3: Filter expression generated internally, not accepted as input
+
+**Decision:** Callers pass `scope`, `namespace`/`cluster_name`, and `exclude_below_severity`. The module generates the GCP filter string:
+
+```
+# scope = "namespace"
+resource.type="k8s_container"
+resource.labels.namespace_name="<namespace>"
+severity<"<exclude_below_severity>"
+
+# scope = "cluster"
+resource.type="k8s_container"
+resource.labels.cluster_name="<cluster_name>"
+severity<"<exclude_below_severity>"
+```
+
+**Rationale:** Callers should not need to know GCP filter syntax. The pattern is fixed and validated — generating it internally prevents typos and ensures consistent structure. `custom_exclusions` remains the escape hatch for arbitrary filters.
+
+---
+
+### D4: Validation via `variable` block `validation` + `precondition` lifecycle
+
+**Decision:** `exclude_below_severity` is validated via a `variable` validation block (allowlist of GCP severity names). The `scope`/`namespace`/`cluster_name` consistency check (namespace required when scope=namespace, cluster_name required when scope=cluster) uses a `precondition` in a `lifecycle` block on the resource, same pattern as the luiss module.
+
+**Rationale:** Variable-level validation catches bad `exclude_below_severity` at `terraform validate`. Preconditions catch the cross-variable constraint at plan time with a clear error message. Both fail early before any GCP API calls.
+
+---
+
+### D5: `custom_exclusions` breaking change is minor and opt-in
+
+**Decision:** Add `enabled = bool` with `default = true` to the `custom_exclusions` object. Existing callers who pass `custom_exclusions` will have their exclusions remain active (default `true`). No action required for callers using the default `{}`.
+
+**Rationale:** `default = true` means existing entries stay active without any change. Callers explicitly using `custom_exclusions` need to add `enabled = true` only if they want to be explicit — it will already be the default.
+
+## Risks / Trade-offs
+
+- **[Risk] `k8s_log_exclusions` name collision with existing named exclusions** → GCP exclusion names must be unique per project. If a caller picks a key like `"health-probe-exclusion"` (already used by the named probe resource), `terraform apply` will fail. Mitigated by documenting reserved names in the variable description.
+- **[Risk] Cluster-scope exclusion silences all workloads in the cluster** → Documented in the `scope` variable description with an explicit warning. Namespace scope is the default.
+- **[Risk] No automatic re-enablement** → GCP has no TTL on exclusions. An exclusion left enabled indefinitely silences logs permanently. Mitigated by the `description` field — callers should record activation date and review intent there.
+- **[Trade-off] `disabled = !enabled` vs `count = 0/1`** → The new `k8s_log_exclusions` and fixed `custom_exclusions` use a different toggle mechanism than the five existing named exclusions. This is intentional (operational vs. structural exclusions) but means the module has two patterns. The divergence is acceptable given the different use cases.
+
+## Migration Plan
+
+1. Update `variables.tf`: add `k8s_log_exclusions`; update `custom_exclusions` object shape
+2. Update `logging_exclusions.tf`: add `k8s_log_exclusions` resource; move `custom_exclusions` resource here
+3. Update `ssl.tf`: remove the misplaced `custom_exclusions` resource block
+4. Update `outputs.tf`: add `k8s_log_exclusions_ids` output
+5. Update `examples/main.tf`: add usage examples for both variables
+6. Update `README.md` via `terraform-docs` (if applicable via Makefile)
+7. Run `make` / `just qa` to validate formatting and lint
+
+**Rollback:** Remove `k8s_log_exclusions` entries and re-apply. Resources are destroyed. The `custom_exclusions` change is backward-compatible (default `enabled = true`).

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/proposal.md
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/proposal.md
@@ -27,4 +27,4 @@ The module currently handles log exclusions as flat, named resources with raw GC
 - Modified file: `ssl.tf` (remove misplaced `custom_exclusions` resource block)
 - Modified file: `outputs.tf` (new `k8s_log_exclusions_ids` map output)
 - Modified file: `examples/main.tf` (usage examples for both new and updated variables)
-- **BREAKING** (minor): `custom_exclusions` object shape changes — existing callers passing `custom_exclusions` must add `enabled = true` to each entry. Default is `{}` so projects not using it are unaffected.
+- **Backward-compatible**: `custom_exclusions` object shape gains `enabled = optional(bool, true)`. Existing callers require no changes — omitting the field defaults to `enabled = true`, preserving current behaviour. Projects not using `custom_exclusions` (default `{}`) are completely unaffected.

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/proposal.md
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The module currently handles log exclusions as flat, named resources with raw GCP filter strings — callers must hand-write filter expressions and have no way to disable an exclusion without destroying and recreating the GCP resource. Projects running Typesense (or any other noisy k8s workload) on GKE need a structured, reusable way to suppress low-severity logs per namespace or cluster, with a safe enable/disable toggle that keeps the resource alive in Terraform state.
+
+## What Changes
+
+- New `k8s_log_exclusions` variable: a map of structured objects that generate GCP log exclusions scoped to a Kubernetes namespace or GKE cluster, with configurable `exclude_below_severity` and an `enabled` toggle. Callers declare namespace/cluster + severity — the module builds the filter internally.
+- Fix `custom_exclusions`: add an `enabled` boolean field to each entry (maps to `disabled = !enabled` on the GCP resource), allowing exclusions to be deactivated without destroying them.
+- Move `custom_exclusions` resource block from `ssl.tf` to `logging_exclusions.tf` where it belongs.
+- Update `outputs.tf` to expose a map of IDs for `k8s_log_exclusions` resources.
+- Update `examples/main.tf` to demonstrate both `k8s_log_exclusions` and `custom_exclusions` usage.
+
+## Capabilities
+
+### New Capabilities
+
+- `k8s-log-exclusions`: A structured, map-driven GCP log exclusion capability scoped to Kubernetes namespaces or GKE clusters. Generates filter expressions internally from `scope`, `namespace`/`cluster_name`, and `exclude_below_severity`. Supports an `enabled` toggle that disables filtering without destroying the Terraform resource.
+
+### Modified Capabilities
+
+- `custom-log-exclusions`: The existing `custom_exclusions` variable gains an `enabled` boolean field per entry, and its resource block is relocated to `logging_exclusions.tf`.
+
+## Impact
+
+- Modified file: `variables.tf` (new `k8s_log_exclusions` variable; updated `custom_exclusions` object shape)
+- Modified file: `logging_exclusions.tf` (new `for_each` resource for `k8s_log_exclusions`; `custom_exclusions` resource moved here)
+- Modified file: `ssl.tf` (remove misplaced `custom_exclusions` resource block)
+- Modified file: `outputs.tf` (new `k8s_log_exclusions_ids` map output)
+- Modified file: `examples/main.tf` (usage examples for both new and updated variables)
+- **BREAKING** (minor): `custom_exclusions` object shape changes — existing callers passing `custom_exclusions` must add `enabled = true` to each entry. Default is `{}` so projects not using it are unaffected.

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/specs/custom-log-exclusions/spec.md
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/specs/custom-log-exclusions/spec.md
@@ -1,0 +1,29 @@
+## MODIFIED Requirements
+
+### Requirement: custom_exclusions entries support an enabled toggle
+Each entry in the `custom_exclusions` map SHALL include an `enabled` boolean field. When `enabled = false`, the GCP exclusion resource SHALL be set to `disabled = true` — the resource persists in Terraform state but does not filter any logs. The field SHALL default to `true` so existing callers are unaffected.
+
+#### Scenario: enabled = true activates filtering (default)
+- **WHEN** an entry has `enabled = true` or `enabled` is not specified
+- **THEN** the GCP exclusion resource SHALL have `disabled = false` and SHALL actively filter matching logs
+
+#### Scenario: enabled = false deactivates without destroying
+- **WHEN** an entry has `enabled = false`
+- **THEN** the GCP exclusion resource SHALL have `disabled = true`, SHALL NOT filter any logs, and SHALL remain in Terraform state
+
+#### Scenario: Toggling enabled does not recreate the resource
+- **WHEN** `enabled` is changed from `true` to `false` (or vice versa)
+- **THEN** `terraform plan` SHALL show an in-place update, not a destroy/recreate
+
+---
+
+### Requirement: custom_exclusions resource block lives in logging_exclusions.tf
+The `google_logging_project_exclusion` resource for `custom_exclusions` SHALL be defined in `logging_exclusions.tf`, not in `ssl.tf`.
+
+#### Scenario: Resource file location
+- **WHEN** a developer inspects `logging_exclusions.tf`
+- **THEN** all `google_logging_project_exclusion` resources — including `custom_exclusions` — SHALL be present in that file
+
+#### Scenario: ssl.tf contains no logging resources
+- **WHEN** a developer inspects `ssl.tf`
+- **THEN** it SHALL contain only SSL policy resources and no `google_logging_project_exclusion` resources

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/specs/k8s-log-exclusions/spec.md
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/specs/k8s-log-exclusions/spec.md
@@ -1,0 +1,99 @@
+## ADDED Requirements
+
+### Requirement: Module accepts structured k8s log exclusion definitions
+The module SHALL accept a `k8s_log_exclusions` variable of type `map(object(...))` where each entry defines a GCP log exclusion scoped to a Kubernetes namespace or GKE cluster. The map key SHALL be used as the GCP exclusion resource name.
+
+#### Scenario: Map with one namespace-scoped entry
+- **WHEN** `k8s_log_exclusions` contains one entry with `scope = "namespace"` and a valid `namespace`
+- **THEN** exactly one `google_logging_project_exclusion` resource SHALL be created with the map key as its name
+
+#### Scenario: Map with multiple entries
+- **WHEN** `k8s_log_exclusions` contains multiple entries
+- **THEN** one `google_logging_project_exclusion` resource SHALL be created per entry, independently
+
+#### Scenario: Empty map (default)
+- **WHEN** `k8s_log_exclusions` is not provided (defaults to `{}`)
+- **THEN** no `google_logging_project_exclusion` resources SHALL be created by this variable
+
+---
+
+### Requirement: Namespace scope generates a namespace-scoped filter
+When an entry has `scope = "namespace"`, the module SHALL generate a GCP log filter targeting `resource.type="k8s_container"` and `resource.labels.namespace_name` equal to the provided `namespace` value.
+
+#### Scenario: Namespace filter structure
+- **WHEN** `scope = "namespace"` and `namespace = "typesense-clusters-stage"` and `exclude_below_severity = "ERROR"`
+- **THEN** the generated filter SHALL be:
+  ```
+  resource.type="k8s_container"
+  resource.labels.namespace_name="typesense-clusters-stage"
+  severity<"ERROR"
+  ```
+
+#### Scenario: namespace is required when scope is namespace
+- **WHEN** `scope = "namespace"` and `namespace` is null or empty
+- **THEN** Terraform SHALL fail at plan time with a clear error message indicating `namespace` is required
+
+---
+
+### Requirement: Cluster scope generates a cluster-scoped filter
+When an entry has `scope = "cluster"`, the module SHALL generate a GCP log filter targeting `resource.type="k8s_container"` and `resource.labels.cluster_name` equal to the provided `cluster_name` value, with no `namespace_name` constraint.
+
+#### Scenario: Cluster filter structure
+- **WHEN** `scope = "cluster"` and `cluster_name = "my-gke-cluster"` and `exclude_below_severity = "WARNING"`
+- **THEN** the generated filter SHALL be:
+  ```
+  resource.type="k8s_container"
+  resource.labels.cluster_name="my-gke-cluster"
+  severity<"WARNING"
+  ```
+
+#### Scenario: cluster_name is required when scope is cluster
+- **WHEN** `scope = "cluster"` and `cluster_name` is null or empty
+- **THEN** Terraform SHALL fail at plan time with a clear error message indicating `cluster_name` is required
+
+---
+
+### Requirement: exclude_below_severity controls which logs are excluded
+The module SHALL exclude all log entries with severity strictly below `exclude_below_severity`. The default SHALL be `"ERROR"`. Valid values SHALL be the GCP severity names: `DEFAULT`, `DEBUG`, `INFO`, `NOTICE`, `WARNING`, `ERROR`, `CRITICAL`, `ALERT`, `EMERGENCY`.
+
+#### Scenario: ERROR threshold (default)
+- **WHEN** `exclude_below_severity` is not provided
+- **THEN** the generated filter SHALL use `severity<"ERROR"`, excluding DEBUG, INFO, NOTICE, WARNING
+
+#### Scenario: WARNING threshold
+- **WHEN** `exclude_below_severity = "WARNING"`
+- **THEN** the generated filter SHALL use `severity<"WARNING"`, excluding DEBUG, INFO, NOTICE
+
+#### Scenario: Invalid severity value
+- **WHEN** `exclude_below_severity` is set to a value not in the allowed list (e.g., `"VERBOSE"`)
+- **THEN** Terraform validation SHALL fail with a clear error listing valid values
+
+---
+
+### Requirement: enabled toggle controls filtering without destroying the resource
+Each entry SHALL expose an `enabled` boolean field. When `enabled = false`, the GCP exclusion resource SHALL be set to `disabled = true` — the resource exists in Terraform state but does not filter any logs. When `enabled = true`, the resource SHALL actively filter matching logs.
+
+#### Scenario: enabled = true activates filtering
+- **WHEN** an entry has `enabled = true`
+- **THEN** the GCP exclusion resource SHALL have `disabled = false` and SHALL filter matching logs
+
+#### Scenario: enabled = false deactivates without destroying
+- **WHEN** an entry has `enabled = false`
+- **THEN** the GCP exclusion resource SHALL have `disabled = true`, SHALL NOT filter any logs, and SHALL remain in Terraform state
+
+#### Scenario: Toggling enabled does not recreate the resource
+- **WHEN** `enabled` is changed from `true` to `false` (or vice versa)
+- **THEN** `terraform plan` SHALL show an in-place update, not a destroy/recreate
+
+---
+
+### Requirement: Module outputs a map of k8s log exclusion resource IDs
+The module SHALL expose a `k8s_log_exclusions_ids` output of type `map(string)` mapping each entry's map key to its GCP `google_logging_project_exclusion` resource ID.
+
+#### Scenario: Output contains all enabled and disabled entries
+- **WHEN** `k8s_log_exclusions` has entries with both `enabled = true` and `enabled = false`
+- **THEN** `k8s_log_exclusions_ids` SHALL contain IDs for all entries regardless of enabled state
+
+#### Scenario: Output is empty when no exclusions defined
+- **WHEN** `k8s_log_exclusions` is `{}`
+- **THEN** `k8s_log_exclusions_ids` SHALL be an empty map

--- a/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/tasks.md
+++ b/openspec/changes/archive/2026-05-11-add-k8s-log-exclusions/tasks.md
@@ -1,0 +1,30 @@
+## 1. Add k8s_log_exclusions variable
+
+- [x] 1.1 Add `k8s_log_exclusions` variable to `variables.tf` as `map(object({ scope, namespace, cluster_name, exclude_below_severity, enabled, description }))` with validations on `scope` and `exclude_below_severity`, defaulting to `{}`
+
+## 2. Implement k8s_log_exclusions resource in logging_exclusions.tf
+
+- [x] 2.1 Add `locals` block to `logging_exclusions.tf` that computes the filter expression per entry based on `scope` (namespace vs cluster) and `exclude_below_severity`
+- [x] 2.2 Add `google_logging_project_exclusion` resource using `for_each = var.k8s_log_exclusions` with `disabled = !each.value.enabled` and `filter = local.k8s_log_exclusion_filters[each.key]`
+- [x] 2.3 Add `precondition` lifecycle blocks to validate namespace/cluster_name are set when their respective scope is selected
+
+## 3. Fix custom_exclusions
+
+- [x] 3.1 Update `custom_exclusions` object type in `variables.tf` to add `enabled = optional(bool, true)` field
+- [x] 3.2 Move `google_logging_project_exclusion.custom_exclusions` resource block from `ssl.tf` to `logging_exclusions.tf`
+- [x] 3.3 Update the resource to use `disabled = !each.value.enabled`
+- [x] 3.4 Remove the `custom_exclusions` resource block from `ssl.tf`
+
+## 4. Update outputs
+
+- [x] 4.1 Add `k8s_log_exclusions_ids` output to `outputs.tf` as `{ for k, v in google_logging_project_exclusion.k8s_log_exclusions : k => v.id }`
+
+## 5. Update examples
+
+- [x] 5.1 Add a `k8s_log_exclusions` example to `examples/main.tf` showing a namespace-scoped entry (e.g., a Typesense namespace) with `enabled = true` and a cluster-scoped entry with `enabled = false`
+- [x] 5.2 Add a `custom_exclusions` example to `examples/main.tf` demonstrating the `enabled` field
+
+## 6. Validate
+
+- [x] 6.1 Run `terraform fmt -recursive` and fix any formatting issues
+- [x] 6.2 Run `terraform validate` (or `make` / `just qa`) and fix any errors

--- a/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/.openspec.yaml
+++ b/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-14

--- a/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/design.md
+++ b/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The `k8s_log_exclusions` variable (added in the `add-k8s-log-exclusions` change) generates GCP Cloud Logging exclusion filters scoped to a namespace or cluster with a severity threshold. This works well for single-workload namespaces but is too broad for shared namespaces. This module already uses both `resource.labels.container_name` (fluentbit exclusion) and `labels.k8s-pod/<key>` (gke-metadata-server exclusion) in its existing hardcoded filters, confirming both patterns are valid in GCP filter syntax.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `container_name` as an optional narrowing selector to `k8s_log_exclusions`
+- Add `pod_label_key` + `pod_label_value` as an optional narrowing selector
+- Both selectors can be used independently or together, always combined with the existing scope (namespace/cluster)
+- Validate that `pod_label_key` and `pod_label_value` are both set or both null (never one without the other)
+- Preserve full backward compatibility — all new fields default to `null`
+
+**Non-Goals:**
+- Supporting multiple pod labels per entry (use multiple entries if needed)
+- Regex matching on container name or label values (GCP filter `=~` syntax — use `custom_exclusions` for that)
+- Changing the `scope` enum — `container_name` and `pod_label` are optional constraints, not new scopes
+
+## Decisions
+
+### D1: Optional selectors, not new scopes
+
+**Decision:** `container_name` and `pod_label_key`/`pod_label_value` are optional fields within the existing object. They are additional `AND` clauses appended to the filter, not mutually exclusive scope modes.
+
+**Rationale:** Container name and pod labels narrow an existing scope — they don't replace it. A container name alone (without namespace/cluster context) would be dangerously broad. Keeping them as optional constraints maintains the existing scope model and allows composable combinations:
+- namespace only
+- namespace + container_name
+- namespace + pod label
+- namespace + container_name + pod label
+- cluster + container_name
+- cluster + pod label
+- cluster + container_name + pod label
+
+**Alternative considered:** Adding `scope = "container"` and `scope = "pod_label"`. Rejected — these aren't scopes, they're selectors within a scope.
+
+---
+
+### D2: Pod label uses `labels.k8s-pod/<key>` syntax
+
+**Decision:** When `pod_label_key` is set, the generated filter clause is `labels.k8s-pod/<pod_label_key>="<pod_label_value>"`.
+
+**Rationale:** This is the documented GCP Cloud Logging filter syntax for Kubernetes pod labels, already in use in this module at `variables.tf:93` for the gke-metadata-server exclusion.
+
+---
+
+### D3: `pod_label_key` and `pod_label_value` must be paired
+
+**Decision:** A validation ensures both are set or both are null. Setting only one is a Terraform validation error.
+
+**Rationale:** A label key without a value (or vice versa) produces a broken filter. This is a straightforward invariant.
+
+---
+
+### D4: Filter assembly uses dynamic list
+
+**Decision:** Instead of branching on scope with a ternary, build a base list of clauses for the scope, then conditionally append `container_name` and pod-label clauses, then join all with `AND`.
+
+**Rationale:** Avoids a combinatorial explosion of ternary branches (2 scopes x 3 optional selectors = many branches). A dynamic list with `concat` + conditional elements is cleaner.
+
+## Risks / Trade-offs
+
+- **[Risk] Pod label keys with special characters** → Keys like `app.kubernetes.io/name` contain dots and slashes. These are valid in GCP filter syntax as `labels.k8s-pod/app.kubernetes.io/name="value"` — no escaping needed. Documented in the variable description.
+- **[Trade-off] Single label only** → Supporting a map of labels per entry adds complexity. A single key/value pair covers the majority use case. Callers needing multiple labels can create multiple exclusion entries, or use `custom_exclusions` for arbitrary filters.

--- a/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/proposal.md
+++ b/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `k8s_log_exclusions` variable currently scopes exclusions to a namespace or cluster, but cannot narrow further to a specific workload. In clusters running multiple services in the same namespace, a namespace-scoped exclusion silences logs for all workloads — not just the noisy one. Adding optional `container_name` and pod-label selectors lets callers target a specific workload without affecting neighbours.
+
+## What Changes
+
+- Extend `k8s_log_exclusions` object type with three new optional fields: `container_name`, `pod_label_key`, and `pod_label_value`.
+- Update filter generation in `logging_exclusions.tf` to conditionally append `resource.labels.container_name` and/or `labels.k8s-pod/<key>` clauses when the fields are set.
+- Add validation: `pod_label_key` and `pod_label_value` must both be set or both be null.
+- Update `examples/main.tf` to demonstrate the new selectors.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `k8s-log-exclusions`: Adds optional `container_name` and `pod_label_key`/`pod_label_value` fields that narrow the exclusion filter to a specific container or pod label within the existing namespace/cluster scope.
+
+## Impact
+
+- Modified file: `variables.tf` (three new optional fields in `k8s_log_exclusions` object, new validation)
+- Modified file: `logging_exclusions.tf` (filter generation updated to append optional clauses)
+- Modified file: `examples/main.tf` (new example entries demonstrating selectors)
+- No breaking changes — new fields are all `optional` with `null` defaults; existing callers are unaffected.

--- a/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/specs/k8s-log-exclusions/spec.md
+++ b/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/specs/k8s-log-exclusions/spec.md
@@ -1,0 +1,53 @@
+## MODIFIED Requirements
+
+### Requirement: Module accepts structured k8s log exclusion definitions
+The module SHALL accept a `k8s_log_exclusions` variable of type `map(object(...))` where each entry defines a GCP log exclusion scoped to a Kubernetes namespace or GKE cluster. The object SHALL include three additional optional fields: `container_name`, `pod_label_key`, and `pod_label_value`. The map key SHALL be used as the GCP exclusion resource name.
+
+#### Scenario: Entry with container_name generates container-scoped filter
+- **WHEN** `scope = "namespace"` and `namespace = "typesense-clusters-stage"` and `container_name = "typesense"` and `exclude_below_severity = "ERROR"`
+- **THEN** the generated filter SHALL be:
+  ```
+  resource.type="k8s_container" AND
+  resource.labels.namespace_name="typesense-clusters-stage" AND
+  resource.labels.container_name="typesense" AND
+  severity<"ERROR"
+  ```
+
+#### Scenario: Entry with pod label generates pod-label-scoped filter
+- **WHEN** `scope = "namespace"` and `namespace = "typesense-clusters-stage"` and `pod_label_key = "app"` and `pod_label_value = "typesense"` and `exclude_below_severity = "ERROR"`
+- **THEN** the generated filter SHALL be:
+  ```
+  resource.type="k8s_container" AND
+  resource.labels.namespace_name="typesense-clusters-stage" AND
+  labels.k8s-pod/app="typesense" AND
+  severity<"ERROR"
+  ```
+
+#### Scenario: Entry with both container_name and pod label
+- **WHEN** `scope = "namespace"` and `namespace = "my-ns"` and `container_name = "web"` and `pod_label_key = "app.kubernetes.io/name"` and `pod_label_value = "my-app"` and `exclude_below_severity = "WARNING"`
+- **THEN** the generated filter SHALL include all clauses: `resource.labels.namespace_name`, `resource.labels.container_name`, `labels.k8s-pod/...`, and `severity<`
+
+#### Scenario: Entry without selectors (backward compatible)
+- **WHEN** `container_name`, `pod_label_key`, and `pod_label_value` are all null (omitted)
+- **THEN** the generated filter SHALL be identical to the previous behaviour (scope + severity only)
+
+#### Scenario: Cluster scope with container_name
+- **WHEN** `scope = "cluster"` and `cluster_name = "dev-cluster"` and `container_name = "nginx"` and `exclude_below_severity = "ERROR"`
+- **THEN** the generated filter SHALL include `resource.labels.cluster_name="dev-cluster"` AND `resource.labels.container_name="nginx"` AND `severity<"ERROR"`
+
+---
+
+### Requirement: pod_label_key and pod_label_value must be paired
+The module SHALL validate that `pod_label_key` and `pod_label_value` are either both set (non-null, non-empty) or both null. Setting only one SHALL produce a Terraform validation error.
+
+#### Scenario: Only pod_label_key is set
+- **WHEN** `pod_label_key = "app"` and `pod_label_value` is null
+- **THEN** Terraform validation SHALL fail with a clear error indicating both must be set together
+
+#### Scenario: Only pod_label_value is set
+- **WHEN** `pod_label_key` is null and `pod_label_value = "typesense"`
+- **THEN** Terraform validation SHALL fail with a clear error indicating both must be set together
+
+#### Scenario: Both set
+- **WHEN** `pod_label_key = "app"` and `pod_label_value = "typesense"`
+- **THEN** validation SHALL pass

--- a/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/tasks.md
+++ b/openspec/changes/archive/2026-05-15-add-k8s-log-exclusion-selectors/tasks.md
@@ -1,0 +1,21 @@
+## 1. Extend k8s_log_exclusions variable
+
+- [x] 1.1 Add `container_name = optional(string)` to the `k8s_log_exclusions` object type in `variables.tf`
+- [x] 1.2 Add `pod_label_key = optional(string)` and `pod_label_value = optional(string)` to the object type
+- [x] 1.3 Add validation that `pod_label_key` and `pod_label_value` are both set or both null
+- [x] 1.4 Update the variable description to document the new fields
+
+## 2. Update filter generation
+
+- [x] 2.1 Refactor `k8s_log_exclusion_filters` local in `logging_exclusions.tf` to build a dynamic clause list: base scope clauses + optional `container_name` + optional pod label + severity
+- [x] 2.2 Add precondition to validate `container_name` is non-empty after trimspace when set (same pattern as namespace/cluster_name)
+
+## 3. Update examples
+
+- [x] 3.1 Add an example entry to `examples/main.tf` demonstrating `container_name`
+- [x] 3.2 Add an example entry demonstrating `pod_label_key` + `pod_label_value`
+
+## 4. Validate
+
+- [x] 4.1 Run `terraform fmt -recursive` and fix any formatting issues
+- [x] 4.2 Run `make lint` and fix any errors

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,11 @@ output "fpm_exclusion_id" {
   value       = lookup(var.enable_exclusions, "fpm", true) ? google_logging_project_exclusion.fpm[0].id : null
 }
 
+output "k8s_log_exclusions_ids" {
+  description = "Map of k8s log exclusion names to their GCP resource IDs"
+  value       = { for k, v in google_logging_project_exclusion.k8s_log_exclusions : k => v.id }
+}
+
 output "ssl_policy_modern_tls_1_2_id" {
   description = "The ID of the SSL policy resource"
   value       = var.enable_ssl_policy ? google_compute_ssl_policy.modern_tls_1_2[0].id : null

--- a/ssl.tf
+++ b/ssl.tf
@@ -13,12 +13,3 @@ resource "google_compute_ssl_policy" "restricted_tls_1_2" {
   description     = "Restricted SSL policy with minimum TLS version 1.2"
   min_tls_version = "TLS_1_2"
 }
-
-resource "google_logging_project_exclusion" "custom_exclusions" {
-  for_each = var.custom_exclusions
-
-  project     = var.project_id
-  name        = each.key
-  description = each.value.description
-  filter      = each.value.filter
-}

--- a/variables.tf
+++ b/variables.tf
@@ -119,10 +119,60 @@ EOT
 }
 
 variable "custom_exclusions" {
-  description = "Map of custom exclusion filters with their descriptions"
+  description = "Map of custom exclusion filters with their descriptions. The map key is used as the GCP exclusion name."
   type = map(object({
     filter      = string
     description = string
+    enabled     = optional(bool, true)
   }))
   default = {}
+}
+
+###########################
+# K8s Log Exclusions
+###########################
+variable "k8s_log_exclusions" {
+  description = <<-EOT
+    Map of structured Kubernetes log exclusions. The map key is used as the GCP exclusion name (must be unique per project).
+    Each entry generates a GCP log exclusion scoped to a Kubernetes namespace or GKE cluster.
+
+    Fields:
+      scope                  - "namespace" to target a single k8s namespace, "cluster" to target all namespaces in a GKE cluster.
+                               WARNING: "cluster" scope silences logs for all workloads in the cluster.
+      namespace              - Required when scope = "namespace". The Kubernetes namespace to filter.
+      cluster_name           - Required when scope = "cluster". The GKE cluster name to filter.
+      exclude_below_severity - Logs with severity strictly below this value are excluded. Defaults to "ERROR".
+                               Valid values: DEFAULT, DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY.
+      enabled                - When false, the GCP exclusion is disabled (resource persists in state but does not filter logs).
+      description            - Human-readable description. Recommended: record activation date and review intent.
+
+    Reserved names (already used by this module): health-probe-exclusion, default-k8s-exclusion,
+    gke-metadata-server-exclusion-sync-sandbox, fluentbit-gke-parse-time, fpm-exclusion.
+  EOT
+  type = map(object({
+    scope                  = string
+    namespace              = optional(string)
+    cluster_name           = optional(string)
+    exclude_below_severity = optional(string, "ERROR")
+    enabled                = optional(bool, true)
+    description            = optional(string, "")
+  }))
+  default = {}
+
+  validation {
+    condition = alltrue([
+      for k, v in var.k8s_log_exclusions : contains(["namespace", "cluster"], v.scope)
+    ])
+    error_message = "Each k8s_log_exclusions entry's 'scope' must be either \"namespace\" or \"cluster\"."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.k8s_log_exclusions : contains([
+        "DEFAULT", "DEBUG", "INFO", "NOTICE", "WARNING",
+        "ERROR", "CRITICAL", "ALERT", "EMERGENCY"
+      ], v.exclude_below_severity)
+    ])
+    error_message = "Each k8s_log_exclusions entry's 'exclude_below_severity' must be one of: DEFAULT, DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -175,4 +175,17 @@ variable "k8s_log_exclusions" {
     ])
     error_message = "Each k8s_log_exclusions entry's 'exclude_below_severity' must be one of: DEFAULT, DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY."
   }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.k8s_log_exclusions : !contains([
+        "health-probe-exclusion",
+        "default-k8s-exclusion",
+        "gke-metadata-server-exclusion-sync-sandbox",
+        "fluentbit-gke-parse-time",
+        "fpm-exclusion",
+      ], k)
+    ])
+    error_message = "k8s_log_exclusions map keys must not use reserved names already managed by this module: health-probe-exclusion, default-k8s-exclusion, gke-metadata-server-exclusion-sync-sandbox, fluentbit-gke-parse-time, fpm-exclusion."
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -156,13 +156,20 @@ variable "custom_exclusions" {
 variable "k8s_log_exclusions" {
   description = <<-EOT
     Map of structured Kubernetes log exclusions. The map key is used as the GCP exclusion name (must be unique per project).
-    Each entry generates a GCP log exclusion scoped to a Kubernetes namespace or GKE cluster.
+    Each entry generates a GCP log exclusion scoped to a Kubernetes namespace or GKE cluster, with optional
+    selectors to narrow to a specific container or pod label.
 
     Fields:
       scope                  - "namespace" to target a single k8s namespace, "cluster" to target all namespaces in a GKE cluster.
                                WARNING: "cluster" scope silences logs for all workloads in the cluster.
       namespace              - Required when scope = "namespace". The Kubernetes namespace to filter.
       cluster_name           - Required when scope = "cluster". The GKE cluster name to filter.
+      container_name         - Optional. Narrow the exclusion to a specific container name
+                               (appends resource.labels.container_name="<value>" to the filter).
+      pod_label_key          - Optional. Kubernetes pod label key to filter on (e.g., "app", "app.kubernetes.io/name").
+                               Must be set together with pod_label_value.
+                               Generates: labels.k8s-pod/<key>="<value>".
+      pod_label_value        - Optional. Value for the pod label key. Must be set together with pod_label_key.
       exclude_below_severity - Logs with severity strictly below this value are excluded. Defaults to "ERROR".
                                Valid values: DEFAULT, DEBUG, INFO, NOTICE, WARNING, ERROR, CRITICAL, ALERT, EMERGENCY.
       enabled                - When false, the GCP exclusion is disabled (resource persists in state but does not filter logs).
@@ -175,6 +182,9 @@ variable "k8s_log_exclusions" {
     scope                  = string
     namespace              = optional(string)
     cluster_name           = optional(string)
+    container_name         = optional(string)
+    pod_label_key          = optional(string)
+    pod_label_value        = optional(string)
     exclude_below_severity = optional(string, "ERROR")
     enabled                = optional(bool, true)
     description            = optional(string, "")
@@ -209,5 +219,13 @@ variable "k8s_log_exclusions" {
       ], k)
     ])
     error_message = "k8s_log_exclusions map keys must not use reserved names already managed by this module: health-probe-exclusion, default-k8s-exclusion, gke-metadata-server-exclusion-sync-sandbox, fluentbit-gke-parse-time, fpm-exclusion."
+  }
+
+  validation {
+    condition = alltrue([
+      for k, v in var.k8s_log_exclusions :
+      (v.pod_label_key == null) == (v.pod_label_value == null)
+    ])
+    error_message = "Each k8s_log_exclusions entry must set both 'pod_label_key' and 'pod_label_value' together, or omit both."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ EOT
 }
 
 variable "custom_exclusions" {
-  description = "Map of custom exclusion filters with their descriptions. The map key is used as the GCP exclusion name."
+  description = "Map of custom exclusion filters with their descriptions. The map key is used as the GCP exclusion name. Each value must include `filter` and `description`, and may optionally set `enabled` (defaults to `true`), which maps to `disabled = !enabled` on the GCP resource."
   type = map(object({
     filter      = string
     description = string

--- a/variables.tf
+++ b/variables.tf
@@ -126,6 +126,28 @@ variable "custom_exclusions" {
     enabled     = optional(bool, true)
   }))
   default = {}
+
+  validation {
+    condition = length(setintersection(
+      toset(keys(var.custom_exclusions)),
+      toset(keys(var.k8s_log_exclusions))
+    )) == 0
+    error_message = "custom_exclusions keys must not overlap with k8s_log_exclusions keys because both map keys are used as GCP exclusion names and must be unique per project."
+  }
+
+  validation {
+    condition = length(setintersection(
+      toset(keys(var.custom_exclusions)),
+      toset([
+        "health-probe-exclusion",
+        "default-k8s-exclusion",
+        "gke-metadata-server-exclusion-sync-sandbox",
+        "fluentbit-gke-parse-time",
+        "fpm-exclusion",
+      ])
+    )) == 0
+    error_message = "custom_exclusions keys must not use module-reserved exclusion names: health-probe-exclusion, default-k8s-exclusion, gke-metadata-server-exclusion-sync-sandbox, fluentbit-gke-parse-time, fpm-exclusion."
+  }
 }
 
 ###########################


### PR DESCRIPTION
Refs: platform/4261
## Summary
This PR introduces structured Kubernetes log exclusions to the module and fixes the existing `custom_exclusions` capability, addressing high-volume log billing incidents caused by noisy workloads (e.g. Typesense Raft recovery) running in GKE namespaces.
Refs: platform/4261
## Changes
### New: `k8s_log_exclusions` variable
A map-driven variable that generates GCP Cloud Logging exclusions scoped to a Kubernetes namespace or GKE cluster. Unlike `custom_exclusions`, callers pass structured inputs and the module builds the filter expression internally.
```hcl
k8s_log_exclusions = {
  "typesense-stage-log-filter" = {
    scope                  = "namespace"
    namespace              = "typesense-clusters-stage"
    exclude_below_severity = "ERROR"
    enabled                = true
    description            = "Suppress Typesense INFO/WARNING logs in stage"
  }
}
Key properties:
- scope — "namespace" (targets a single k8s namespace) or "cluster" (targets all namespaces in a GKE cluster — use with care)
- exclude_below_severity — logs strictly below this GCP severity level are excluded (default: "ERROR")
- enabled — when false, the GCP exclusion is disabled but the Terraform resource is preserved in state; toggling does not destroy/recreate the resource
- Map key becomes the GCP exclusion resource name (must be unique per project — reserved names documented in variable description)
New output: k8s_log_exclusions_ids — map of exclusion name → GCP resource ID.
Fix: custom_exclusions — added enabled toggle
The custom_exclusions object shape gains an enabled = optional(bool, true) field. Previously, disabling a custom exclusion required removing it from the map, destroying the GCP resource. Now callers can set enabled = false to deactivate filtering without destroying the resource.
> Minor breaking change: existing callers passing custom_exclusions entries will continue to work unchanged (field defaults to true). Callers using the default {} are completely unaffected.
Fix: custom_exclusions resource relocated
The google_logging_project_exclusion resource block for custom_exclusions was incorrectly placed in ssl.tf. It has been moved to logging_exclusions.tf where it belongs.
Toggle behaviour
Both k8s_log_exclusions and custom_exclusions use disabled = !enabled on the GCP resource, meaning the resource always exists in Terraform state. This is intentional for operational use cases — activating or deactivating a filter during an incident requires only a terraform apply, with no destroy/recreate cycle.
The five existing named exclusions (probe_exclusion, default_k8s_exclusion, etc.) are unchanged and continue to use count = 0/1 toggled via enable_exclusions.
Files changed
File
variables.tf
logging_exclusions.tf
ssl.tf
outputs.tf
examples/main.tf
```
Assisted-by: opencode/github-copilot/claude-sonnet-4.6