### PR TITLE
feat(logging)!: make cluster_name required for all k8s_log_exclusions scopes

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -184,6 +184,7 @@ module "infrastructure_elements" {
     # Silence Typesense Raft recovery noise in stage (actively enabled)
     "typesense-stage-log-filter" = {
       scope                  = "namespace"
+      cluster_name           = "gke-test-1"
       namespace              = "typesense-clusters-stage"
       exclude_below_severity = "ERROR"
       enabled                = true
@@ -192,6 +193,7 @@ module "infrastructure_elements" {
     # Production filter created but disabled — activate during incidents
     "typesense-prod-log-filter" = {
       scope                  = "namespace"
+      cluster_name           = "gke-prod-1"
       namespace              = "typesense-clusters-main"
       exclude_below_severity = "ERROR"
       enabled                = false
@@ -208,6 +210,7 @@ module "infrastructure_elements" {
     # Example: namespace + container_name selector — target a specific container
     "typesense-stage-container-filter" = {
       scope                  = "namespace"
+      cluster_name           = "gke-test-1"
       namespace              = "typesense-clusters-stage"
       container_name         = "typesense"
       exclude_below_severity = "ERROR"
@@ -217,6 +220,7 @@ module "infrastructure_elements" {
     # Example: namespace + pod label selector — target pods by Kubernetes label
     "typesense-stage-pod-label-filter" = {
       scope                  = "namespace"
+      cluster_name           = "gke-test-1"
       namespace              = "typesense-clusters-stage"
       pod_label_key          = "app.kubernetes.io/name"
       pod_label_value        = "typesense"

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -14,11 +14,15 @@ locals {
   # Clauses are joined with AND to match established module style and avoid Cloud Logging filter ambiguity.
   k8s_log_exclusion_filters = {
     for k, v in var.k8s_log_exclusions : k => join(" AND\n", concat(
-      # Base: resource type + scope clause
-      ["resource.type=\"k8s_container\""],
+      # Base: resource type + cluster (always present)
+      [
+        "resource.type=\"k8s_container\"",
+        "resource.labels.cluster_name=\"${trimspace(v.cluster_name)}\"",
+      ],
+      # Namespace clause (only for namespace scope)
       v.scope == "namespace"
       ? ["resource.labels.namespace_name=\"${trimspace(coalesce(v.namespace, ""))}\""]
-      : ["resource.labels.cluster_name=\"${trimspace(coalesce(v.cluster_name, ""))}\""],
+      : [],
       # Optional: container name selector
       v.container_name != null && trimspace(v.container_name) != ""
       ? ["resource.labels.container_name=\"${trimspace(v.container_name)}\""]
@@ -92,13 +96,18 @@ resource "google_logging_project_exclusion" "k8s_log_exclusions" {
 
   lifecycle {
     precondition {
+      condition     = trimspace(each.value.cluster_name) != ""
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'cluster_name' must be a non-empty string."
+    }
+
+    precondition {
       condition     = !(each.value.scope == "namespace" && (each.value.namespace == null || trimspace(each.value.namespace) == ""))
       error_message = "k8s_log_exclusions[\"${each.key}\"]: 'namespace' must be set to a non-empty string when scope is \"namespace\"."
     }
 
     precondition {
-      condition     = !(each.value.scope == "cluster" && (each.value.cluster_name == null || trimspace(each.value.cluster_name) == ""))
-      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'cluster_name' must be set to a non-empty string when scope is \"cluster\"."
+      condition     = !(each.value.scope == "cluster" && each.value.namespace != null)
+      error_message = "k8s_log_exclusions[\"${each.key}\"]: 'namespace' must not be set when scope is \"cluster\"."
     }
 
     precondition {

--- a/variables.tf
+++ b/variables.tf
@@ -162,8 +162,9 @@ variable "k8s_log_exclusions" {
     Fields:
       scope                  - "namespace" to target a single k8s namespace, "cluster" to target all namespaces in a GKE cluster.
                                WARNING: "cluster" scope silences logs for all workloads in the cluster.
+      cluster_name           - Required. The GKE cluster name to scope the exclusion to.
       namespace              - Required when scope = "namespace". The Kubernetes namespace to filter.
-      cluster_name           - Required when scope = "cluster". The GKE cluster name to filter.
+                               Must NOT be set when scope = "cluster".
       container_name         - Optional. Narrow the exclusion to a specific container name
                                (appends resource.labels.container_name="<value>" to the filter).
       pod_label_key          - Optional. Kubernetes pod label key to filter on (e.g., "app", "app.kubernetes.io/name").
@@ -180,8 +181,8 @@ variable "k8s_log_exclusions" {
   EOT
   type = map(object({
     scope                  = string
+    cluster_name           = string
     namespace              = optional(string)
-    cluster_name           = optional(string)
     container_name         = optional(string)
     pod_label_key          = optional(string)
     pod_label_value        = optional(string)


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Syphon83._

## Summary

- Makes `cluster_name` a **required** field for both `scope = "namespace"` and `scope = "cluster"` in `k8s_log_exclusions`
- Filter builder now always includes `resource.labels.cluster_name` clause, eliminating ambiguity in multi-cluster projects
- Adds precondition: `namespace` must NOT be set when `scope = "cluster"`

## Breaking Change

`cluster_name` is no longer optional — all entries must specify it. Acceptable since v0.4.0 has zero consumers.

## Example (namespace scope)

```hcl
k8s_log_exclusions = {
  "typesens-test1-log-filter" = {
    scope                  = "namespace"
    cluster_name           = "test1"
    namespace              = "typesens"
    exclude_below_severity = "ERROR"
    enabled                = true
    description            = "Exclude logs below ERROR for namespace typesens in cluster test1"
  }
}
```

Refs: sparkfabrik/terraform-google-gcp-infrastructure-elements#4261