### PR TITLE
fix(logging): resolve null argument errors in variable validations and preconditions

### DIFF
--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -24,7 +24,7 @@ locals {
       ? ["resource.labels.namespace_name=\"${trimspace(coalesce(v.namespace, ""))}\""]
       : [],
       # Optional: container name selector
-      v.container_name != null && trimspace(v.container_name) != ""
+      v.container_name != null
       ? ["resource.labels.container_name=\"${trimspace(v.container_name)}\""]
       : [],
       # Optional: pod label selector

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -111,17 +111,17 @@ resource "google_logging_project_exclusion" "k8s_log_exclusions" {
     }
 
     precondition {
-      condition     = each.value.container_name == null || trimspace(each.value.container_name) != ""
+      condition     = try(trimspace(each.value.container_name) != "", true)
       error_message = "k8s_log_exclusions[\"${each.key}\"]: 'container_name' must be non-empty when set."
     }
 
     precondition {
-      condition     = each.value.pod_label_key == null || trimspace(each.value.pod_label_key) != ""
+      condition     = try(trimspace(each.value.pod_label_key) != "", true)
       error_message = "k8s_log_exclusions[\"${each.key}\"]: 'pod_label_key' must be non-empty when set."
     }
 
     precondition {
-      condition     = each.value.pod_label_value == null || trimspace(each.value.pod_label_value) != ""
+      condition     = try(trimspace(each.value.pod_label_value) != "", true)
       error_message = "k8s_log_exclusions[\"${each.key}\"]: 'pod_label_value' must be non-empty when set."
     }
   }

--- a/logging_exclusions.tf
+++ b/logging_exclusions.tf
@@ -127,6 +127,22 @@ resource "google_logging_project_exclusion" "k8s_log_exclusions" {
   }
 }
 
+# Cross-variable validation: ensure custom_exclusions and k8s_log_exclusions keys
+# don't overlap, since both map keys become GCP exclusion names (unique per project).
+# This cannot live inside a variable validation block (Terraform < 1.9 restriction),
+# so we use a terraform_data precondition which evaluates at plan time.
+resource "terraform_data" "validate_exclusion_keys" {
+  lifecycle {
+    precondition {
+      condition = length(setintersection(
+        toset(keys(var.custom_exclusions)),
+        toset(keys(var.k8s_log_exclusions))
+      )) == 0
+      error_message = "custom_exclusions keys must not overlap with k8s_log_exclusions keys because both map keys are used as GCP exclusion names and must be unique per project."
+    }
+  }
+}
+
 # Custom log exclusions with arbitrary GCP filter strings.
 # The map key is used as the GCP exclusion name.
 # The resource persists in state even when enabled = false (disabled = true in GCP).

--- a/variables.tf
+++ b/variables.tf
@@ -130,14 +130,6 @@ variable "custom_exclusions" {
   validation {
     condition = length(setintersection(
       toset(keys(var.custom_exclusions)),
-      toset(keys(var.k8s_log_exclusions))
-    )) == 0
-    error_message = "custom_exclusions keys must not overlap with k8s_log_exclusions keys because both map keys are used as GCP exclusion names and must be unique per project."
-  }
-
-  validation {
-    condition = length(setintersection(
-      toset(keys(var.custom_exclusions)),
       toset([
         "health-probe-exclusion",
         "default-k8s-exclusion",


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @Syphon83._

## Summary

- Moves cross-variable key overlap check from `variable "custom_exclusions"` validation (illegal in Terraform < 1.9) to a `terraform_data` precondition
- Guards `trimspace()` calls against null values in filter builder (Terraform doesn't short-circuit `&&`/`||`)
- Uses `try(trimspace(x) != "", true)` pattern in preconditions for nullable optional fields

## Fixes

- `Error: Invalid reference in variable validation` — custom_exclusions referencing var.k8s_log_exclusions
- `Error: Invalid function argument` — trimspace called on null container_name, pod_label_key, pod_label_value

## Testing

Verified in consumer project — plan produces correct filter output with no errors.

Refs: sparkfabrik/terraform-google-gcp-infrastructure-elements#4261